### PR TITLE
Add airmass scaling to PWV transmission

### DIFF
--- a/notebooks/simulating_lc_with_cadence.ipynb
+++ b/notebooks/simulating_lc_with_cadence.ipynb
@@ -32,11 +32,13 @@
     "from astropy.io import fits\n",
     "from astropy.table import Table\n",
     "from astropy.time import Time\n",
+    "from astropy.coordinates import SkyCoord\n",
+    "from astropy import units as u\n",
     "from matplotlib import pyplot as plt\n",
     "from pwv_kpno.gps_pwv import GPSReceiver\n",
     "\n",
     "sys.path.insert(0, '../')\n",
-    "from sn_analysis import filters, plasticc, plotting, sn_magnitudes, modeling \n"
+    "from sn_analysis import filters, plasticc, plotting, sn_magnitudes, modeling, constants \n"
    ]
   },
   {
@@ -47,7 +49,7 @@
    "source": [
     "filters.register_lsst_filters(force=True)\n",
     "\n",
-    "plt.rcParams['figure.dpi'] = 100\n",
+    "plt.rcParams['figure.dpi'] = 100  # Enable HDPI\n",
     "print('Simulation data directory:', plasticc.plasticc_simulations_directory)\n"
    ]
   },
@@ -494,12 +496,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "variable_pwv_effect = modeling.VariablePWVTrans(pwv_interpolator, scale_airmass=False)\n",
-    "variable_pwv_effect.set(res=5)\n",
+    "pwv_effect_no_airmass = modeling.VariablePWVTrans(pwv_interpolator, scale_airmass=False)\n",
+    "pwv_effect_no_airmass.set(res=5)\n",
     "\n",
     "demo_model = modeling.Model(\n",
     "    source='salt2-extended',\n",
-    "    effects=[variable_pwv_effect],\n",
+    "    effects=[pwv_effect_no_airmass],\n",
     "    effect_names=[''],\n",
     "    effect_frames=['obs']\n",
     ")\n",
@@ -513,6 +515,75 @@
     "        'x1': -1.8,\n",
     "        'c': -0.1}\n",
     ")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Airmass Scaling\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": false
+   },
+   "outputs": [],
+   "source": [
+    "def plot_airmass_validation(cadence, model=11, mjd=0):\n",
+    "    ra = []\n",
+    "    dec = []\n",
+    "    peak = []\n",
+    "\n",
+    "    for header_path in plasticc.get_model_headers(cadence, 11):\n",
+    "        header_data = fits.open(header_path)[1].data\n",
+    "        ra.extend(header_data['RA'])\n",
+    "        dec.extend(header_data['DECL'])\n",
+    "        if mjd == 'peak':\n",
+    "            peak.extend(header_data['PEAKMJD'])\n",
+    "\n",
+    "    if mjd == 'peak':\n",
+    "        mjd = peak\n",
+    "    \n",
+    "    airmass = modeling.calc_airmass(\n",
+    "        time=mjd,\n",
+    "        ra=ra,\n",
+    "        dec=dec,\n",
+    "        lat=constants.vro_latitude.value,\n",
+    "        lon=constants.vro_longitude.value,\n",
+    "        alt=constants.vro_longitude.value\n",
+    "    )\n",
+    "\n",
+    "    \n",
+    "    is_positive_airmass = np.array(airmass) >= 0 \n",
+    "    positive_airmass = airmass[is_positive_airmass]\n",
+    "    \n",
+    "    lsst_coord = SkyCoord(constants.vro_latitude, constants.vro_longitude).galactic\n",
+    "    sn_coord = SkyCoord(ra, dec, unit=u.deg).galactic\n",
+    "    positive_coords = sn_coord[is_positive_airmass]\n",
+    "    negative_coords = sn_coord[~is_positive_airmass]\n",
+    "    \n",
+    "    plt.figure(figsize=(10, 5))\n",
+    "    plt.subplot(111, projection='aitoff')\n",
+    "    plt.grid(True)\n",
+    "    \n",
+    "    scat = plt.scatter(positive_coords.l.wrap_at('180d').radian, positive_coords.b.radian, c=positive_airmass, vmin=1, vmax=8, s=10)\n",
+    "    plt.scatter(negative_coords.l.wrap_at('180d').radian, negative_coords.b.radian, c='lightgrey', label='Over Horizon')\n",
+    "    plt.scatter(lsst_coord.l.wrap_at('180d').radian, lsst_coord.b.radian,color='C1', marker='*', s=100, label='VRO')\n",
+    "    plt.legend(framealpha=1)\n",
+    "    plt.colorbar(scat).set_label('Airmass', rotation=270, labelpad=15)\n",
+    "    "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plot_airmass_validation(demo_cadence)\n"
    ]
   },
   {
@@ -546,7 +617,7 @@
     "        verbose              (bool): Display a progress bar\n",
     "    \"\"\"\n",
     "    \n",
-    "    model = copy(model)\n",
+    "    # model = copy(model)\n",
     "    \n",
     "    # Determine redshift limit of the given model\n",
     "    u_band_low = sncosmo.get_bandpass('lsst_hardware_u').minwave()\n",
@@ -611,6 +682,23 @@
    "metadata": {},
    "source": [
     "We pause to visually check a light-curves from our iterator. As a simple validation, we simulate light-curves with and without PWV."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "variable_pwv_effect = modeling.VariablePWVTrans(pwv_interpolator)\n",
+    "variable_pwv_effect.set(res=5)\n",
+    "\n",
+    "sn_model_with_pwv = modeling.Model(\n",
+    "    source='salt2-extended',\n",
+    "    effects=[variable_pwv_effect],\n",
+    "    effect_names=[''],\n",
+    "    effect_frames=['obs']\n",
+    ")\n"
    ]
   },
   {

--- a/notebooks/simulating_lc_with_cadence.ipynb
+++ b/notebooks/simulating_lc_with_cadence.ipynb
@@ -23,6 +23,7 @@
    "source": [
     "import sys\n",
     "import warnings\n",
+    "from copy import copy\n",
     "from datetime import datetime, timedelta\n",
     "\n",
     "import numpy as np\n",
@@ -493,18 +494,18 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "variable_pwv_effect = modeling.VariablePWVTrans(pwv_interpolator)\n",
+    "variable_pwv_effect = modeling.VariablePWVTrans(pwv_interpolator, scale_airmass=False)\n",
     "variable_pwv_effect.set(res=5)\n",
     "\n",
-    "model_with_pwv = modeling.Model(\n",
+    "demo_model = modeling.Model(\n",
     "    source='salt2-extended',\n",
     "    effects=[variable_pwv_effect],\n",
-    "    effect_names=['PWV_transmission'],\n",
+    "    effect_names=[''],\n",
     "    effect_frames=['obs']\n",
     ")\n",
     "\n",
     "plot_variable_pwv_model(\n",
-    "    model_with_pwv,     \n",
+    "    demo_model,     \n",
     "    params = {\n",
     "        'z': 0.752069652,\n",
     "        't0': 61900,\n",
@@ -545,6 +546,9 @@
     "        verbose              (bool): Display a progress bar\n",
     "    \"\"\"\n",
     "    \n",
+    "    model = copy(model)\n",
+    "    \n",
+    "    # Determine redshift limit of the given model\n",
     "    u_band_low = sncosmo.get_bandpass('lsst_hardware_u').minwave()\n",
     "    source_low = model.source.minwave()\n",
     "    zlim = (u_band_low / source_low) - 1\n",
@@ -559,7 +563,12 @@
     "        if light_curve.meta['SIM_REDSHIFT_CMB'] >= zlim:\n",
     "            continue\n",
     "        \n",
+    "        model.set(ra=light_curve.meta['RA'], dec=light_curve.meta['DECL'])\n",
     "        duplicated_lc = plasticc.duplicate_plasticc_sncosmo(light_curve, model, gain=gain, skynr=skynr)\n",
+    "        \n",
+    "        # sncosmo.plot_lc(duplicated_lc)\n",
+    "        # plt.show()\n",
+    "\n",
     "        if quality_callback and not quality_callback(duplicated_lc):\n",
     "            continue\n",
     "            \n",
@@ -612,7 +621,7 @@
    },
    "outputs": [],
    "source": [
-    "l = next(iter_custom_lcs(model_with_pwv, demo_cadence, verbose=False))\n",
+    "l = next(iter_custom_lcs(sn_model_with_pwv, demo_cadence, verbose=False))\n",
     "sncosmo.plot_lc(l);\n"
    ]
   },
@@ -624,20 +633,7 @@
    },
    "outputs": [],
    "source": [
-    "model_without_pwv = sncosmo.Model('salt2-extended')\n",
-    "l = next(iter_custom_lcs(model_without_pwv, demo_cadence, verbose=False))\n",
-    "sncosmo.plot_lc(l);\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
-   "outputs": [],
-   "source": [
-    "light_curves = iter_custom_lcs(model_with_pwv, demo_cadence, iter_lim=10, quality_callback=passes_quality_cuts)\n",
+    "light_curves = iter_custom_lcs(sn_model_with_pwv, demo_cadence, iter_lim=10, quality_callback=passes_quality_cuts)\n",
     "\n",
     "model_without_pwv = sncosmo.Model('salt2-extended')\n",
     "fitted_mag, fitted_params = sn_magnitudes.fit_mag(\n",

--- a/notebooks/sne_delta_mag.ipynb
+++ b/notebooks/sne_delta_mag.ipynb
@@ -23,7 +23,7 @@
     "import numpy as np\n",
     "import sncosmo\n",
     "from matplotlib import pyplot as plt\n",
-    "from sn_analysis import modeling, sn_magnitudes, reference, plotting\n",
+    "from sn_analysis import modeling, sn_magnitudes, reference, plotting, constants\n",
     "from sn_analysis.filters import register_lsst_filters\n"
    ]
   },
@@ -55,7 +55,7 @@
     "model_without_pwv = sncosmo.Model(_source)\n",
     "\n",
     "model_with_pwv = sncosmo.Model(_source)\n",
-    "model_with_pwv.add_effect(modeling.PWVTrans(), '', 'obs')\n",
+    "model_with_pwv.add_effect(modeling.StaticPWVTrans(), '', 'obs')\n",
     "\n",
     "pwv_vals = np.arange(0, 11)\n",
     "z_vals = np.arange(.01, 1.05, .05)\n",
@@ -545,7 +545,7 @@
    "outputs": [],
    "source": [
     "# Account for (what I think is) a numerical error between astropy and sncosmo\n",
-    "numerical_error_offset = fitted_mu[0] - modeling.betoule_cosmo.distmod(z_vals).value\n",
+    "numerical_error_offset = fitted_mu[0] - constants.betoule_cosmo.distmod(z_vals).value\n",
     "\n",
     "plotting.plot_delta_mu(fitted_mu - numerical_error_offset, pwv_vals, z_vals)\n"
    ]
@@ -586,7 +586,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "numerical_error_offset_ref = fitted_mu_with_ref[0] - modeling.betoule_cosmo.distmod(z_vals).value\n",
+    "numerical_error_offset_ref = fitted_mu_with_ref[0] - constants.betoule_cosmo.distmod(z_vals).value\n",
     "plotting.plot_delta_mu(fitted_mu_with_ref - numerical_error_offset_ref, pwv_vals, z_vals)\n"
    ]
   },

--- a/sn_analysis/constants.py
+++ b/sn_analysis/constants.py
@@ -1,0 +1,20 @@
+# !/usr/bin/env python3
+# -*- coding: UTF-8 -*-
+
+"""Defines values for constants used across the parent package."""
+
+from astropy import units as _u
+from astropy.cosmology import FlatLambdaCDM as _FlatLambdaCDM
+
+# Vera Rubin Observatory coordinates from Google Maps
+vro_latitude = -30.244573 * _u.deg
+vro_longitude = -70.7499537 * _u.deg
+vro_altitude = 1024 * _u.m
+
+# Fitted parameters from the cosmological analysis of Betoule et al. 2014
+betoule_alpha = 0.141
+betoule_beta = 3.101
+betoule_omega_m = 0.295
+betoule_abs_mb = -19.05
+betoule_H0 = 70
+betoule_cosmo = _FlatLambdaCDM(H0=betoule_H0, Om0=betoule_omega_m)

--- a/sn_analysis/modeling.py
+++ b/sn_analysis/modeling.py
@@ -289,6 +289,10 @@ class Model(sncosmo.Model):
             new_model.__dict__[key] = val
 
         new_model._parameters = self._parameters.copy()
+
+        # Link ids of new parameters in memory
+        # Otherwise parameters wont update correctly in the copied object
+        new_model._sync_parameter_arrays()
         return new_model
 
 

--- a/sn_analysis/modeling.py
+++ b/sn_analysis/modeling.py
@@ -11,7 +11,9 @@ from pathlib import Path
 
 import numpy as np
 import sncosmo
+from astropy import units as u
 from astropy.coordinates import AltAz
+from astropy.coordinates import EarthLocation
 from astropy.cosmology import FlatLambdaCDM
 from astropy.table import Table
 from astropy.time import Time
@@ -116,9 +118,10 @@ class VariablePWVTrans(VariablePropagationEffect):
         self._maxwave = self._transmission_model.samp_wave.max()
 
         # Define and store default modeling parameters
+        default_lsst_location = EarthLocation(lat=-30.244573 * u.deg, lon=-70.7499537 * u.deg, height=1024 * u.m)
         self._param_names = ['location', 'coord', 'res']
         self.param_names_latex = ['Location', 'Coordinate', 'Resolution']
-        self._parameters = np.array([None, None, 5.])
+        self._parameters = np.array([default_lsst_location, None, 5.])
 
     def calc_pwv_los(self, time):
         """Return the PWV along the line of sight for a given time
@@ -131,7 +134,7 @@ class VariablePWVTrans(VariablePropagationEffect):
         """
 
         pwv_zenith = self._pwv_interpolator(time)
-        if self['location'] is None:
+        if self['coord'] is None:
             return pwv_zenith
 
         with warnings.catch_warnings():

--- a/sn_analysis/modeling.py
+++ b/sn_analysis/modeling.py
@@ -117,6 +117,13 @@ class VariablePWVTrans(VariablePropagationEffect):
         Set ``scale_airmass`` to ``False`` if ``pwv_interpolator`` returns PWV values along the
         line of sight.
 
+        Effect Parameters:
+            ra: Target Right Ascension in degrees
+            dec: Target Declination in degrees
+            lat: Observer latitude in degrees (defaults to location of VRO)
+            lon: Observer longitude in degrees (defaults to location of VRO)
+            alt: Observer altitude in meters  (defaults to height of VRO)
+
         Args:
             pwv_interpolator (callable[float]): Returns PWV at zenith for a given time value
             time_format                  (str): Astropy recognized time format used by the ``pwv_interpolator``

--- a/sn_analysis/plasticc.py
+++ b/sn_analysis/plasticc.py
@@ -12,7 +12,7 @@ from astropy.io import fits
 from astropy.table import Table
 from tqdm import tqdm
 
-from . import modeling
+from . import modeling, constants as const
 
 try:
     plasticc_simulations_directory = Path(os.environ['CADENCE_SIMS'])
@@ -178,7 +178,7 @@ def extract_cadence_data(light_curve, drop_nondetection=False, zp=25, gain=5, sk
 
 
 def duplicate_plasticc_sncosmo(
-        light_curve, model, gain=5, skynr=100, scatter=True, cosmo=modeling.betoule_cosmo):
+        light_curve, model, gain=5, skynr=100, scatter=True, cosmo=const.betoule_cosmo):
     """Simulate a light-curve with sncosmo that matches the cadence of a PLaSTICC light-curve
 
     Args:

--- a/sn_analysis/plotting.py
+++ b/sn_analysis/plotting.py
@@ -60,7 +60,7 @@ from matplotlib.ticker import MultipleLocator
 from pwv_kpno.defaults import v1_transmission
 from pytz import utc
 
-from . import modeling, filters
+from . import modeling, filters, constants as const
 
 filters.register_lsst_filters(force=True)
 
@@ -372,10 +372,10 @@ def plot_fitted_params(fitted_params, pwv_arr, z_arr, bands):
         axis.set_xlabel('Redshift')
         axis.set_ylabel(param)
 
-    correction_factor = modeling.alpha * params_dict['x1'] - modeling.beta * params_dict['c']
+    correction_factor = const.betoule_alpha * params_dict['x1'] - const.betoule_beta * params_dict['c']
     multi_line_plot(z_arr, correction_factor, pwv_arr, axes[-1][-1], label='PWV = {:g} mm')
 
-    label = f'{modeling.alpha} * $x_1$ - {modeling.beta} * $c$'
+    label = f'{const.betoule_alpha} * $x_1$ - {const.betoule_beta} * $c$'
     axes[-1][-1].set_ylabel(label)
     axes[-1][-1].legend(bbox_to_anchor=(1, 1.1))
 
@@ -449,7 +449,7 @@ def plot_delta_colors(pwv_arr, z_arr, mag_dict, colors, ref_pwv=0):
 
 
 # noinspection PyUnusedLocal
-def plot_delta_mu(mu, pwv_arr, z_arr, cosmo=modeling.betoule_cosmo):
+def plot_delta_mu(mu, pwv_arr, z_arr, cosmo=const.betoule_cosmo):
     """Plot the variation in fitted distance modulus as a function of redshift and PWV
 
     Args:

--- a/sn_analysis/sn_magnitudes.py
+++ b/sn_analysis/sn_magnitudes.py
@@ -17,7 +17,7 @@ import sncosmo
 import yaml
 from tqdm import tqdm
 
-from . import modeling
+from . import modeling, constants as const
 
 _PARENT = Path(__file__).resolve()
 _CONFIG_PATH = _PARENT.parent.parent / 'ref_pwv.yaml'  # Reference pwv values
@@ -134,7 +134,7 @@ def tabulate_fiducial_mag(model, z_arr, bands, fid_pwv_dict=None):
 ###############################################################################
 
 
-def correct_mag(model, mag, params, alpha=modeling.alpha, beta=modeling.beta):
+def correct_mag(model, mag, params, alpha=const.betoule_alpha, beta=const.betoule_beta):
     """Correct fitted supernova magnitude for stretch and color
 
     calibrated mag = mag + α * x1 - β * c
@@ -292,11 +292,12 @@ def calc_delta_mag(mag, fiducial_mag, fiducial_pwv):
 # Distance Modulus Calculations
 ###############################################################################
 
-def calc_mu_for_model(model):
+def calc_mu_for_model(model, cosmo=const.betoule_cosmo):
     """Calculate the distance modulus of a model
 
     Args:
-        model (Model): An sncosmo model
+        mode    l (Model): An sncosmo model
+        cosmo (Cosmology): Cosmology to use in the calculation
 
     Returns:
         mu = m_B - M_B
@@ -309,7 +310,7 @@ def calc_mu_for_model(model):
     rest_band = b_band.shifted(dilation_factor)
 
     apparent_mag = model.bandmag(rest_band, 'ab', 0) - time_dilation_mag_offset
-    absolute_mag = model.source_peakabsmag(b_band, 'ab', cosmo=modeling.betoule_cosmo)
+    absolute_mag = model.source_peakabsmag(b_band, 'ab', cosmo=cosmo)
     return apparent_mag - absolute_mag
 
 
@@ -357,4 +358,4 @@ def calc_calibration_factor_for_params(model, params):
         i, param in enumerate(model.param_names)
     }
 
-    return modeling.alpha * params_dict['x1'] - modeling.beta * params_dict['c']
+    return const.betoule_alpha * params_dict['x1'] - const.betoule_beta * params_dict['c']

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -1,0 +1,29 @@
+# !/usr/bin/env python3
+# -*- coding: UTF-8 -*-
+
+"""Tests for the ``constants`` module"""
+
+from unittest import TestCase
+
+import astropy.units as u
+
+from sn_analysis import constants as const
+
+
+class Dimensions(TestCase):
+    """Test dimensional units have units expected by the rest of the package"""
+
+    def test_vro_latitude_units(self):
+        """Test ``constants.vro_latitude`` is in units of degrees"""
+
+        self.assertEqual(const.vro_latitude.unit, u.deg)
+
+    def test_vro_longitude_units(self):
+        """Test ``constants.vro_longitude`` is in units of degrees"""
+
+        self.assertEqual(const.vro_longitude.unit, u.deg)
+
+    def test_vro_altitude_units(self):
+        """Test ``constants.vro_altitude`` is in units of meters"""
+
+        self.assertEqual(const.vro_altitude.unit, u.m)

--- a/tests/test_modeling.py
+++ b/tests/test_modeling.py
@@ -146,6 +146,14 @@ class TestModel(sncosmo_test_models.TestModel, TestCase):
         model.add_effect(effect=effect, frame='obs', name='Variable PWV')
         model.flux(time=0, wave=[4000])
 
+    def test_sed_matches_sncosmo_model(self):
+        wave = np.arange(3000, 12000)
+        sncosmo_model = sncosmo.Model('salt2-extended')
+        sncosmo_flux = sncosmo_model.flux(0, wave)
+        custom_model = modeling.Model(sncosmo_model.source)
+        custom_flux = custom_model.flux(0, wave)
+        np.testing.assert_equal(custom_flux, sncosmo_flux)
+
 
 class TestPWVTrans(TestCase):
     """Tests for the addition of PWV to sncosmo models"""

--- a/tests/test_modeling.py
+++ b/tests/test_modeling.py
@@ -38,6 +38,20 @@ class TestVariablePWVTrans(TestCase):
         self.constant_pwv_func = lambda *args: self.default_pwv
         self.propagation_effect = modeling.VariablePWVTrans(self.constant_pwv_func)
 
+    def test_default_coord_is_none(self):
+        """Test the default value for the ``coord`` model parameter is ``None``"""
+
+        self.assertIsNone(self.propagation_effect['coord'])
+
+    def test_default_location_is_vro(self):
+        """Test the default value for the ``coord`` model parameter matches ``VRO``"""
+
+        from astropy.coordinates import EarthLocation
+        import astropy.units as u
+
+        lsst_location = EarthLocation(lat=-30.244573 * u.deg, lon=-70.7499537 * u.deg, height=1024 * u.m)
+        self.assertEqual(self.propagation_effect['location'], lsst_location)
+
     def test_transmission_version_support(self):
         """Test the propagation object uses the atmospheric model corresponding specified at init"""
 

--- a/tests/test_modeling.py
+++ b/tests/test_modeling.py
@@ -33,29 +33,31 @@ class TestVariablePropagationEffect(TestCase):
 class TestVariablePWVTrans(TestCase):
     """Tests for the ``modeling.VariablePWVTrans`` class"""
 
+    vro_latitude = -30.244573  # degrees
+    vro_lingitude = -70.7499537  # degrees
+    vro_altitude = 1024  # meters
+
     def setUp(self):
         self.default_pwv = 5
         self.constant_pwv_func = lambda *args: self.default_pwv
         self.propagation_effect = modeling.VariablePWVTrans(self.constant_pwv_func)
 
-    def test_default_coord_is_none(self):
-        """Test the default value for the ``coord`` model parameter is ``None``"""
+    def test_default_location_params_match_vro(self):
+        """Test the default values for the observer location match VRO"""
 
-        self.assertIsNone(self.propagation_effect['coord'])
+        self.assertEqual(self.propagation_effect['lat'], self.vro_latitude)
+        self.assertEqual(self.propagation_effect['lon'], self.vro_lingitude)
+        self.assertEqual(self.propagation_effect['alt'], self.vro_altitude)
 
-    def test_default_location_is_vro(self):
-        """Test the default value for the ``location`` model parameter matches ``VRO``"""
+    def test_airmass_scaling_on_by_default(self):
+        """Test airmass scaling is turned on by default"""
 
-        from astropy.coordinates import EarthLocation
-        import astropy.units as u
-
-        lsst_location = EarthLocation(lat=-30.244573 * u.deg, lon=-70.7499537 * u.deg, height=1024 * u.m)
-        self.assertEqual(self.propagation_effect['location'], lsst_location)
+        self.assertTrue(self.propagation_effect.scale_airmass)
 
     def test_transmission_version_support(self):
         """Test the propagation object uses the atmospheric model corresponding specified at init"""
 
-        from pwv_kpno.transmission import CrossSectionTransmission, TransmissionModel
+        from pwv_kpno.transmission import CrossSectionTransmission
 
         default_effect = modeling.VariablePWVTrans(self.constant_pwv_func)
         self.assertIsInstance(default_effect._transmission_model, CrossSectionTransmission)
@@ -75,10 +77,22 @@ class TestVariablePWVTrans(TestCase):
 
         wave = np.arange(3000, 12000)
         flux = np.ones_like(wave)
-        transmission = self.propagation_effect._transmission_model(self.default_pwv, wave, self.propagation_effect['res'])
+
+        self.propagation_effect.scale_airmass = False
+        transmission = self.propagation_effect._transmission_model(
+            self.default_pwv, wave, self.propagation_effect['res'])
 
         propagated_flux = self.propagation_effect.propagate(wave, flux, time=0)
         np.testing.assert_equal(propagated_flux, transmission.values)
+
+    def test_pwv_los_is_scaled_by_airmass(self):
+        """Test PWV is scaled by airmass when the ``scale_airmass`` attribute is ``True``"""
+
+        self.propagation_effect.scale_airmass = True
+        self.propagation_effect.set(ra=2, dec=2)
+        airmass = self.propagation_effect.airmass(time=0)
+        pwv_los = self.propagation_effect.calc_pwv_los(time=0)
+        self.assertEqual(pwv_los, self.default_pwv * airmass)
 
 
 class TestModel(sncosmo_test_models.TestModel, TestCase):
@@ -123,6 +137,14 @@ class TestModel(sncosmo_test_models.TestModel, TestCase):
         model = modeling.Model(source='salt2')
         model.add_effect(effect=sncosmo.CCM89Dust(), frame='free', name=effect_name)
         self.assertIn(effect_name + 'z', model.param_names)
+
+    def test_variable_propagation_support(self):
+        """Test a time variable effect can be added and called without error"""
+
+        effect = modeling.VariablePWVTrans(lambda *args: 5)
+        model = modeling.Model(sncosmo_test_models.flatsource())
+        model.add_effect(effect=effect, frame='obs', name='Variable PWV')
+        model.flux(time=0, wave=[4000])
 
 
 class TestPWVTrans(TestCase):

--- a/tests/test_modeling.py
+++ b/tests/test_modeling.py
@@ -44,7 +44,7 @@ class TestVariablePWVTrans(TestCase):
         self.assertIsNone(self.propagation_effect['coord'])
 
     def test_default_location_is_vro(self):
-        """Test the default value for the ``coord`` model parameter matches ``VRO``"""
+        """Test the default value for the ``location`` model parameter matches ``VRO``"""
 
         from astropy.coordinates import EarthLocation
         import astropy.units as u


### PR DESCRIPTION
This PR adds an optional airmass scaling to PWV values used by the  `VariablePWVTrans` effect. Some notes on the implimentation:
- Airmass values are determined using `astropy` builtins
- New parameters for the transmission effect are target RA, target DEC, observer longitude, observer latitude, and observer altitude. All units are expected in either degrees of meters.
- The object defaults to assuming targets are observed from the longitude, latitude, and altitude of VRO (as determined from Google maps). 

To help keep the package organized, this PR also includes a new `constants` module to keep useful numbers / default parameters all in one place.