### PR TITLE
Add additional SN properties to fitting pipeline output file

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -38,7 +38,7 @@ jobs:
         pip install coveralls
         
     - name: Install package and dependencies
-      run: pip install .
+      run: pip install .[tests]
         
     - name: Run tests with coverage
       run: |

--- a/docs/source/overview/install.rst
+++ b/docs/source/overview/install.rst
@@ -17,12 +17,21 @@ from the GitHub repository page or by using the ``git`` command line utility:
    git clone  --depth=1 --branch=master https://github.com/LSSTDESC/SN-PWV.git SN-PWV
    rm -rf ./SN-PWV/.git
 
-Project dependencies are listed in the ``requirements.txt`` file included with
-the source code. Dependencies can be installed using ``pip``:
+The package can then be installed into your working environment manually, or
+using ``pip``:
 
 .. code-block:: bash
 
-   pip install -r SN-PWV/requirements.txt
+   cd SN-PWV
+   pip install .
+
+If you want to run the package's test suite, you will also need to install
+the test suite dependencies:
+
+.. code-block:: bash
+
+   cd SN-PWV
+   pip install .[tests]
 
 
 Downloading Light-Curve Sims

--- a/setup.py
+++ b/setup.py
@@ -26,5 +26,8 @@ setup(name='snat_sim',
       license='GPL v3',
       python_requires='>=3.8',
       install_requires=requirements,
-      include_package_data=True
+      include_package_data=True,
+      extras_require={
+          'tests': ['sndata']
+      }
       )

--- a/snat_sim/__init__.py
+++ b/snat_sim/__init__.py
@@ -4,6 +4,8 @@ variability will impact Supernovae observed by the Legacy Survey of Space and
 Time (LSST).
 """
 
+# Explicitly import fitting_pipeline to register pandas accessors
+from snat_sim import fitting_pipeline
 from . import *
 
 __version__ = 'Development'

--- a/snat_sim/fitting_pipeline.py
+++ b/snat_sim/fitting_pipeline.py
@@ -35,140 +35,15 @@ Module Docs
 
 import multiprocessing as mp
 import warnings
-from dataclasses import dataclass
-from functools import wraps
 from pathlib import Path
 
 import numpy as np
 import pandas as pd
 import sncosmo
 from astropy.cosmology import FlatwCDM
-from astropy.table import Table
 from iminuit import Minuit
 
 from . import plasticc, reference_stars
-
-
-@dataclass
-class PipelineResults:
-    """Parser for data outputted by the snat_sim fitting pipeline"""
-
-    def __init__(self, path):
-        self._data = Table.read(path).to_pandas()
-
-    def calc_distmod(self, abs_mag):
-        """Return the distance modulus for an assumed absolute magnitude
-
-        Args:
-            abs_mag (float): The B-band absolute magnitude
-
-        Returns:
-            The distance modulus
-        """
-
-        return abs_mag - self['mb']
-
-    @wraps(pd.DataFrame.sample)
-    def sample(self, *args, **kwargs):
-        new_obj = self.__new__(type(self))
-        new_obj._data = self._data.sample(*args, **kwargs)
-        return new_obj
-
-    @wraps(pd.DataFrame.__getitem__)
-    def __getitem__(self, item):
-        return self._data[item]
-
-
-class CosmologyFitter(PipelineResults):
-    """Chi-squared minimizer for fitting a cosmology to pipeline results"""
-
-    # noinspection PyPep8Naming
-    def chisq(self, H0, Om0, abs_mag, w0):
-        """Calculate the chi-squared for given cosmological parameters
-
-        Args:
-            H0      (float): Hubble constant
-            Om0     (float): Matter density
-            abs_mag (float): SNe Ia intrinsic peak magnitude
-            w0      (float): Dark matter equation of state
-
-        Returns:
-            The chi-squared of the resulting cosmology
-        """
-
-        measured_mu = self.calc_distmod(abs_mag)
-
-        cosmology = FlatwCDM(H0=H0, Om0=Om0, w0=w0)
-        modeled_mu = cosmology.distmod(self['z']).value
-        return np.sum(((measured_mu - modeled_mu) ** 2) / (self['mb_err'] ** 2))
-
-    def chisq_grid(self, H0, Om0, abs_mag, w0):
-        """Calculate the chi-squared on a grid of cosmological parameters
-
-        Arguments are automatically repeated along the grid so that the
-        dimensions of each array match.
-
-        Args:
-            H0      (float, ndarray): Hubble constant
-            Om0     (float, ndarray): Matter density
-            abs_mag (float, ndarray): SNe Ia intrinsic peak magnitude
-            w0      (float, ndarray): Dark matter equation of state
-
-        Returns:
-            An array of chi-squared values
-        """
-
-        new_args = self._match_argument_dimensions(H0, Om0, abs_mag, w0)
-        return np.vectorize(self.chisq)(*new_args)
-
-    @staticmethod
-    def _match_argument_dimensions(*args):
-        """Reshape arguments so they match the shape of the argument with the
-        most dimensions.
-
-        Args:
-            *args (float, ndarray): Values to cast onto the grid
-
-        Returns:
-            A list with each argument cast to it's new shape
-        """
-
-        # Get the shape of the argument with the most dimensions
-        grid_shape = np.shape(args[np.argmax([np.ndim(arg) for arg in args])])
-
-        # Reshape each argument to match the dimensions from above
-        return [np.full(grid_shape, arg) for arg in args]
-
-    def minimize(self, **kwargs):
-        """Fit cosmology to the instantiated data
-
-        Kwargs:
-            Accepts any iminuit style keyword arguments for parameters
-              ``H0``, ``Om0``, ``abs_mag``, and ``w0``.
-
-        Returns:
-            Optimized Minuit object
-        """
-
-        minimizer = Minuit(self.chisq, **kwargs)
-        minimizer.migrad()
-        return minimizer
-
-    def minimize_mc(self, samples, n=None, frac=None, **kwargs):
-        """Fit cosmology to the instantiated data using monte carlo resampling
-
-        Args:
-            samples (int): Number of samples to draw
-            n       (int): Size of each sample. Cannot be used with ``frac``
-            frac  (float): Fraction of data to include in each sample. Cannot be used with ``size``
-            Accepts any iminuit style keyword arguments for parameters
-              ``H0``, ``Om0``, ``abs_mag``, and ``w0``.
-
-        Returns:
-            Optimized Minuit object
-        """
-
-        return [self.sample(n=n, frac=frac).minimize(**kwargs) for _ in range(samples)]
 
 
 class KillSignal:
@@ -375,3 +250,111 @@ class FittingPipeline(ProcessManager):
                 else:
                     new_line = ','.join(map(str, results)) + '\n'
                     outfile.write(new_line)
+
+
+@pd.api.extensions.register_dataframe_accessor("snat_sim")
+class CosmologyAccessor:
+    """Chi-squared minimizer for fitting a cosmology to pipeline results"""
+
+    def __init__(self, pandasobject):
+        self.data = pandasobject
+
+    def calc_distmod(self, abs_mag):
+        """Return the distance modulus for an assumed absolute magnitude
+
+        Args:
+            abs_mag (float): The B-band absolute magnitude
+
+        Returns:
+            The distance modulus
+        """
+
+        return abs_mag - self.data['mb']
+
+    # noinspection PyPep8Naming
+    def chisq(self, H0, Om0, abs_mag, w0):
+        """Calculate the chi-squared for given cosmological parameters
+
+        Args:
+            H0      (float): Hubble constant
+            Om0     (float): Matter density
+            abs_mag (float): SNe Ia intrinsic peak magnitude
+            w0      (float): Dark matter equation of state
+
+        Returns:
+            The chi-squared of the resulting cosmology
+        """
+
+        measured_mu = self.calc_distmod(abs_mag)
+
+        cosmology = FlatwCDM(H0=H0, Om0=Om0, w0=w0)
+        modeled_mu = cosmology.distmod(self.data['z']).value
+        return np.sum(((measured_mu - modeled_mu) ** 2) / (self.data['mb_err'] ** 2))
+
+    def chisq_grid(self, H0, Om0, abs_mag, w0):
+        """Calculate the chi-squared on a grid of cosmological parameters
+
+        Arguments are automatically repeated along the grid so that the
+        dimensions of each array match.
+
+        Args:
+            H0      (float, ndarray): Hubble constant
+            Om0     (float, ndarray): Matter density
+            abs_mag (float, ndarray): SNe Ia intrinsic peak magnitude
+            w0      (float, ndarray): Dark matter equation of state
+
+        Returns:
+            An array of chi-squared values
+        """
+
+        new_args = self._match_argument_dimensions(H0, Om0, abs_mag, w0)
+        return np.vectorize(self.chisq)(*new_args)
+
+    @staticmethod
+    def _match_argument_dimensions(*args):
+        """Reshape arguments so they match the shape of the argument with the
+        most dimensions.
+
+        Args:
+            *args (float, ndarray): Values to cast onto the grid
+
+        Returns:
+            A list with each argument cast to it's new shape
+        """
+
+        # Get the shape of the argument with the most dimensions
+        grid_shape = np.shape(args[np.argmax([np.ndim(arg) for arg in args])])
+
+        # Reshape each argument to match the dimensions from above
+        return [np.full(grid_shape, arg) for arg in args]
+
+    def minimize(self, **kwargs):
+        """Fit cosmology to the instantiated data
+
+        Kwargs:
+            Accepts any iminuit style keyword arguments for parameters
+              ``H0``, ``Om0``, ``abs_mag``, and ``w0``.
+
+        Returns:
+            Optimized Minuit object
+        """
+
+        minimizer = Minuit(self.chisq, **kwargs)
+        minimizer.migrad()
+        return minimizer
+
+    def minimize_mc(self, samples, n=None, frac=None, **kwargs):
+        """Fit cosmology to the instantiated data using monte carlo resampling
+
+        Args:
+            samples (int): Number of samples to draw
+            n       (int): Size of each sample. Cannot be used with ``frac``
+            frac  (float): Fraction of data to include in each sample. Cannot be used with ``size``
+            Accepts any iminuit style keyword arguments for parameters
+              ``H0``, ``Om0``, ``abs_mag``, and ``w0``.
+
+        Returns:
+            Optimized Minuit object
+        """
+
+        return [self.data.sample(n=n, frac=frac).snat_sim.minimize(**kwargs) for _ in range(samples)]

--- a/snat_sim/fitting_pipeline.py
+++ b/snat_sim/fitting_pipeline.py
@@ -280,6 +280,8 @@ class FittingPipeline(ProcessManager, OutputDataModel):
         kill_count = 0  # Count closed upstream processes so this process knows when to exit
 
         with self.out_path.open('w') as outfile:
+            outfile.write(','.join(self.result_table_col_names(self.fit_model)))
+
             while True:
                 if isinstance(results := self.queue_fit_results.get(), KillSignal):
                     kill_count += 1

--- a/snat_sim/fitting_pipeline.py
+++ b/snat_sim/fitting_pipeline.py
@@ -273,7 +273,7 @@ class CosmologyAccessor:
         return self.data['mb'] - abs_mag
 
     # noinspection PyPep8Naming
-    def chisq(self, H0, Om0, abs_mag, w0):
+    def chisq(self, H0, Om0, abs_mag, w0, alpha, beta):
         """Calculate the chi-squared for given cosmological parameters
 
         Args:
@@ -281,12 +281,14 @@ class CosmologyAccessor:
             Om0     (float): Matter density
             abs_mag (float): SNe Ia intrinsic peak magnitude
             w0      (float): Dark matter equation of state
+            alpha   (float): Stretch correction nuisance parameter
+            beta    (float): Color correction nuisance parameter
 
         Returns:
             The chi-squared of the resulting cosmology
         """
 
-        measured_mu = self.calc_distmod(abs_mag)
+        measured_mu = self.calc_distmod(abs_mag) + alpha * self.data['x1'] - beta * self.data['c']
 
         cosmology = FlatwCDM(H0=H0, Om0=Om0, w0=w0)
         modeled_mu = cosmology.distmod(self.data['z']).value

--- a/snat_sim/fitting_pipeline.py
+++ b/snat_sim/fitting_pipeline.py
@@ -257,8 +257,8 @@ class FittingPipeline(ProcessManager):
 class CosmologyAccessor:
     """Chi-squared minimizer for fitting a cosmology to pipeline results"""
 
-    def __init__(self, pandasobject):
-        self.data = pandasobject
+    def __init__(self, pandas_obj):
+        self.data = pandas_obj
 
     def calc_distmod(self, abs_mag):
         """Return the distance modulus for an assumed absolute magnitude
@@ -363,8 +363,9 @@ class CosmologyAccessor:
             samples = [self.data.sample(n=n, frac=frac).snat_sim.minimize(**kwargs).np_values() for _ in range(samples)]
             stat_val = statistic(samples)
 
+            # Create a dictionary mapping the argument name to the applies statistic
             arg_names = inspect.getfullargspec(self.chisq).args
-            samples = dict(zip(arg_names[1:], stat_val))
+            samples = dict(zip(arg_names[1:], stat_val))  # first argument is self, so drop it
 
         else:
             samples = [self.data.sample(n=n, frac=frac).snat_sim.minimize(**kwargs) for _ in range(samples)]

--- a/snat_sim/fitting_pipeline.py
+++ b/snat_sim/fitting_pipeline.py
@@ -232,6 +232,7 @@ class FittingPipeline(ProcessManager):
         out_list.extend(result.errors.values())
         out_list.append(result.chisq)
         out_list.append(result.ndof)
+        out_list.append(fitted_model.source_peakabsmag('bessellb', 'ab'))
         return out_list
 
     def _fit_light_curves(self):

--- a/snat_sim/fitting_pipeline.py
+++ b/snat_sim/fitting_pipeline.py
@@ -364,7 +364,7 @@ class CosmologyAccessor:
             stat_val = statistic(samples)
 
             arg_names = inspect.getfullargspec(self.chisq).args
-            samples = dict(zip(arg_names, stat_val))
+            samples = dict(zip(arg_names[1:], stat_val))
 
         else:
             samples = [self.data.sample(n=n, frac=frac).snat_sim.minimize(**kwargs) for _ in range(samples)]

--- a/snat_sim/fitting_pipeline.py
+++ b/snat_sim/fitting_pipeline.py
@@ -44,7 +44,7 @@ import sncosmo
 from astropy.cosmology import FlatwCDM
 from iminuit import Minuit
 
-from . import plasticc, reference_stars
+from . import plasticc, reference_stars, constants as const
 
 
 class KillSignal:
@@ -232,7 +232,7 @@ class FittingPipeline(ProcessManager):
         out_list.extend(result.errors.values())
         out_list.append(result.chisq)
         out_list.append(result.ndof)
-        out_list.append(fitted_model.source_peakabsmag('bessellb', 'ab'))
+        out_list.append(fitted_model.source_peakabsmag('bessellb', 'ab', cosmo=const.betoule_cosmo))
         return out_list
 
     def _fit_light_curves(self):

--- a/snat_sim/fitting_pipeline.py
+++ b/snat_sim/fitting_pipeline.py
@@ -294,7 +294,7 @@ class CosmologyAccessor:
         modeled_mu = cosmology.distmod(self.data['z']).value
         return np.sum(((measured_mu - modeled_mu) ** 2) / (self.data['mb_err'] ** 2))
 
-    def chisq_grid(self, H0, Om0, abs_mag, w0):
+    def chisq_grid(self, H0, Om0, abs_mag, w0, alpha, beta):
         """Calculate the chi-squared on a grid of cosmological parameters
 
         Arguments are automatically repeated along the grid so that the
@@ -305,12 +305,14 @@ class CosmologyAccessor:
             Om0     (float, ndarray): Matter density
             abs_mag (float, ndarray): SNe Ia intrinsic peak magnitude
             w0      (float, ndarray): Dark matter equation of state
+            alpha            (float): Stretch correction nuisance parameter
+            beta             (float): Color correction nuisance parameter
 
         Returns:
             An array of chi-squared values
         """
 
-        new_args = self._match_argument_dimensions(H0, Om0, abs_mag, w0)
+        new_args = self._match_argument_dimensions(H0, Om0, abs_mag, w0, alpha, beta)
         return np.vectorize(self.chisq)(*new_args)
 
     @staticmethod

--- a/snat_sim/fitting_pipeline.py
+++ b/snat_sim/fitting_pipeline.py
@@ -79,7 +79,7 @@ class PipelineResults:
         return self._data[item]
 
 
-class HubbleMinimizer(PipelineResults):
+class CosmologyFitter(PipelineResults):
     """Chi-squared minimizer for fitting a cosmology to pipeline results"""
 
     # noinspection PyPep8Naming

--- a/tests/mock.py
+++ b/tests/mock.py
@@ -77,3 +77,52 @@ def create_mock_plasticc_light_curve():
             'SIM_SALT2x0': 1
         }
     )
+
+
+def create_mock_pipeline_outputs(path=None):
+    """Create a mock table of results from the snat_sim pipeline using DES SN3YR data
+
+    Args:
+        path (str, Path): Optionally write the table to a path instead of returning it
+
+    Returns:
+        An astropy table if ``path`` is not given
+    """
+
+    from sndata.des import SN3YR
+
+    # Download DES data if not already available
+    sn3yr = SN3YR()
+    sn3yr.download_module_data()
+
+    # Load DES fit results and format them to match pipeline outputs
+    pipeline_fits = sn3yr.load_table('SALT2mu_DES+LOWZ_C11.FITRES')
+    pipeline_fits.rename_column('CID', 'snid')
+    pipeline_fits.rename_column('zCMB', 'z')
+    pipeline_fits.rename_column('zCMBERR', 'z_err')
+    pipeline_fits.rename_column('PKMJD', 't0')
+    pipeline_fits.rename_column('PKMJDERR', 't0_err')
+    pipeline_fits.rename_column('x0ERR', 'x0_err')
+    pipeline_fits.rename_column('x1ERR', 'x1_err')
+    pipeline_fits.rename_column('cERR', 'c_err')
+    pipeline_fits.rename_column('NDOF', 'dof')
+    pipeline_fits.rename_column('FITCHI2', 'chisq')
+    pipeline_fits.rename_column('RA', 'ra')
+    pipeline_fits.rename_column('DECL', 'dec')
+    pipeline_fits.rename_column('mB', 'mb')
+    pipeline_fits.rename_column('mBERR', 'mb_err')
+    pipeline_fits.meta = dict()
+
+    # Keep only the data outputted by the snat_sim fitting pipeline
+    keep_columns = ['snid', 'dof', 'chisq', 'ra', 'dec', 'mb', 'mb_err']
+    for param in ['z', 't0', 'x0', 'x1', 'c']:
+        keep_columns.append(param)
+        keep_columns.append(param + '_err')
+    pipeline_fits = pipeline_fits[keep_columns]
+
+    # Write to path or return
+    if path:
+        pipeline_fits.write(path)
+
+    else:
+        return pipeline_fits

--- a/tests/mock.py
+++ b/tests/mock.py
@@ -79,11 +79,8 @@ def create_mock_plasticc_light_curve():
     )
 
 
-def create_mock_pipeline_outputs(path=None):
-    """Create a mock table of results from the snat_sim pipeline using DES SN3YR data
-
-    Args:
-        path (str, Path): Optionally write the table to a path instead of returning it
+def create_mock_pipeline_outputs():
+    """Create DataFrame with mock results from the snat_sim pipeline using DES SN3YR data
 
     Returns:
         An astropy table if ``path`` is not given
@@ -119,10 +116,4 @@ def create_mock_pipeline_outputs(path=None):
         keep_columns.append(param)
         keep_columns.append(param + '_err')
     pipeline_fits = pipeline_fits[keep_columns]
-
-    # Write to path or return
-    if path:
-        pipeline_fits.write(path)
-
-    else:
-        return pipeline_fits
+    return pipeline_fits.to_pandas()

--- a/tests/test_cosmology_accessor.py
+++ b/tests/test_cosmology_accessor.py
@@ -7,6 +7,7 @@ import numpy as np
 import pandas as pd
 
 from snat_sim import constants as const
+from snat_sim.fitting_pipeline import CosmologyAccessor
 from tests import mock
 
 
@@ -70,3 +71,103 @@ class MCResampling(TestCase):
         # Test the dictionary is built  with correct key value mapping
         for param in ('H0', 'Om0', 'abs_mag', 'w0'):
             np.testing.assert_allclose(statistic[param], stat_func([s.values[param] for s in samples]))
+
+
+class ChisqGrid(TestCase):
+    """Tests for the ``chisq_grid`` function"""
+
+    def setUp(self):
+        self.test_data = mock.create_mock_pipeline_outputs()
+
+    def test_grid_values_match_chisq_function(self):
+        """Test returned grid values match the ``chisq`` calculation"""
+
+        # Calculate chisq for two different w0 values so chisq values are also different
+        chisq1 = self.test_data.snat_sim.chisq(
+            w0=-1,
+            H0=const.betoule_H0,
+            Om0=const.betoule_omega_m,
+            abs_mag=const.betoule_abs_mb
+        )
+
+        chisq2 = self.test_data.snat_sim.chisq(
+            w0=0,
+            H0=const.betoule_H0,
+            Om0=const.betoule_omega_m,
+            abs_mag=const.betoule_abs_mb
+        )
+
+        chisq_grid = self.test_data.snat_sim.chisq_grid(
+            const.betoule_H0, const.betoule_omega_m, const.betoule_abs_mb, [-1, 0])
+
+        np.testing.assert_allclose(chisq_grid, [chisq1, chisq2])
+
+
+class MatchArgumentDimensions(TestCase):
+    """Tests for the ``_match_argument_dimensions`` function"""
+
+    @staticmethod
+    def assert_return(inputs, expected):
+        """For input arguments ``input`` assert the returned array matches ``expected``
+
+        Args:
+            inputs  (tuple): Arguments for ``_match_argument_dimensions``
+            expected (list): Expected return values
+        """
+
+        returned = CosmologyAccessor._match_argument_dimensions(*inputs)
+        np.testing.assert_array_equal(returned, expected)
+
+    def assert_return_matching_dimensions(self, inputs):
+        """For input arguments ``input`` assert the returned array matches ``list(input)``
+
+        Args:
+            inputs  (tuple): Arguments for ``_match_argument_dimensions``
+        """
+
+        self.assert_return(inputs, list(inputs))
+
+    def test_all_floats(self):
+        """Test return for all float arguments"""
+
+        inputs = 1, 2
+        self.assert_return_matching_dimensions(inputs)
+
+    def test_all_1d(self):
+        """Test return for all 1D arguments"""
+
+        inputs = [1], [2]
+        self.assert_return_matching_dimensions(inputs)
+
+    def test_all_2d(self):
+        """Test return for all 2D arguments"""
+
+        inputs = [[1, 2], [1, 2]], [[5, 6], [7, 8]]
+        self.assert_return_matching_dimensions(inputs)
+
+    def test_float_1d(self):
+        """Test return for mixed float and 1D arguments"""
+
+        inputs = 1, [2, 3]
+        expected = [[1, 1], [2, 3]]
+        self.assert_return(inputs, expected)
+
+    def test_float_2d(self):
+        """Test return for mixed float and 2D arguments"""
+
+        inputs = 1, [[2, 3], [4, 5]]
+        expected = [np.ones((2, 2)), inputs[1]]
+        self.assert_return(inputs, expected)
+
+    def test_1d_2d(self):
+        """Test return for mixed 1D and 2D arguments"""
+
+        inputs = [1, 2], [[2, 3], [4, 5]]
+        expected = [[[1, 2], [1, 2]], inputs[1]]
+        self.assert_return(inputs, expected)
+
+    def test_error_on_mismatched_dimensions(self):
+        """Test an error is raised when input arguments cannot be cast to match dimensions"""
+
+        with self.assertRaises(ValueError):
+            CosmologyAccessor._match_argument_dimensions([1, 2], [1, 2, 3])

--- a/tests/test_cosmology_accessor.py
+++ b/tests/test_cosmology_accessor.py
@@ -87,18 +87,27 @@ class ChisqGrid(TestCase):
             w0=-1,
             H0=const.betoule_H0,
             Om0=const.betoule_omega_m,
-            abs_mag=const.betoule_abs_mb
+            abs_mag=const.betoule_abs_mb,
+            alpha=0,
+            beta=0
         )
 
         chisq2 = self.test_data.snat_sim.chisq(
             w0=0,
             H0=const.betoule_H0,
             Om0=const.betoule_omega_m,
-            abs_mag=const.betoule_abs_mb
+            abs_mag=const.betoule_abs_mb,
+            alpha=0,
+            beta=0
         )
 
         chisq_grid = self.test_data.snat_sim.chisq_grid(
-            const.betoule_H0, const.betoule_omega_m, const.betoule_abs_mb, [-1, 0])
+            w0=[-1, 0],
+            H0=const.betoule_H0,
+            Om0=const.betoule_omega_m,
+            abs_mag=const.betoule_abs_mb,
+            alpha=0,
+            beta=0)
 
         np.testing.assert_allclose(chisq_grid, [chisq1, chisq2])
 

--- a/tests/test_cosmology_accessor.py
+++ b/tests/test_cosmology_accessor.py
@@ -1,0 +1,72 @@
+"""Tests for the ``CosmologyAccessor`` class"""
+
+from functools import partial
+from unittest import TestCase
+
+import numpy as np
+import pandas as pd
+
+from snat_sim import constants as const
+from tests import mock
+
+
+class AccessorRegistration(TestCase):
+    """Test the ``snat_sim`` accessor is registered with ``pandas``"""
+
+    def runTest(self):
+        self.assertTrue(pd.DataFrame().snat_sim)
+
+
+class DistanceModulus(TestCase):
+    """Tests for the chi-squared minimization"""
+
+    def setUp(self):
+        self.test_data = mock.create_mock_pipeline_outputs()
+
+    def test_returns_distance_modulus(self):
+        """Test the returned value matches the distance modulus"""
+
+        abs_mag = -19.1
+        dist_mod = self.test_data['mb'] - abs_mag
+        returned = self.test_data.snat_sim.calc_distmod(abs_mag)
+        pd.testing.assert_series_equal(returned, dist_mod)
+
+
+class MCResampling(TestCase):
+    """Tests for the chi-squared minimization"""
+
+    def setUp(self):
+        self.test_data = mock.create_mock_pipeline_outputs()
+
+        # Arguments to ensure the minimization converges and quickly
+        self.iminuit_kwargs = dict(
+            H0=const.betoule_H0,
+            Om0=const.betoule_omega_m,
+            limit_Om0=(0, 1),
+            w0=-1,
+            fix_w0=True,
+            abs_mag=const.betoule_abs_mb,
+            fix_abs_mag=True
+        )
+
+    def test_correct_number_of_samples(self):
+        """Test the correct number of samples are drawn from the dataset"""
+
+        num_samples = 3
+        samples = self.test_data.snat_sim.minimize_mc(num_samples, frac=1, **self.iminuit_kwargs)
+        self.assertIsInstance(samples, list)
+        self.assertEqual(len(samples), num_samples)
+
+    def test_statistic_returns_dict(self):
+        """Test supplying a statistic argument returns a dict of the applies statistic"""
+
+        num_samples = 3
+        stat_func = partial(np.average, axis=0)
+        samples = self.test_data.snat_sim.minimize_mc(num_samples, frac=1, **self.iminuit_kwargs)
+        statistic = self.test_data.snat_sim.minimize_mc(num_samples, frac=1, statistic=stat_func, **self.iminuit_kwargs)
+
+        self.assertIsInstance(statistic, dict)
+
+        # Test the dictionary is built  with correct key value mapping
+        for param in ('H0', 'Om0', 'abs_mag', 'w0'):
+            np.testing.assert_allclose(statistic[param], stat_func([s.values[param] for s in samples]))

--- a/tests/test_fitting_pipeline.py
+++ b/tests/test_fitting_pipeline.py
@@ -8,7 +8,7 @@ import sncosmo
 from snat_sim.fitting_pipeline import FittingPipeline
 
 
-class TestProcessAllocation(TestCase):
+class ProcessAllocation(TestCase):
     """Tests for the allocation of processes to each pipeline task"""
 
     def setUp(self):

--- a/tests/test_fitting_pipeline.py
+++ b/tests/test_fitting_pipeline.py
@@ -1,5 +1,6 @@
-"""Tests for the ``fitting_pipeline`` module"""
+"""Tests for the ``FittingPipeline`` class"""
 
+from tempfile import NamedTemporaryFile
 from unittest import TestCase
 
 import sncosmo
@@ -9,6 +10,12 @@ from snat_sim.fitting_pipeline import FittingPipeline
 
 class TestProcessAllocation(TestCase):
     """Tests for the allocation of processes to each pipeline task"""
+
+    def setUp(self):
+        self.temp_file = NamedTemporaryFile()
+
+    def tearDown(self):
+        self.temp_file.close()
 
     def test_allocations_sum_to_pool_size(self):
         """Test the number of allocated processes sum to the total pool size"""
@@ -20,7 +27,7 @@ class TestProcessAllocation(TestCase):
             fit_model=sncosmo.Model('salt2'),
             vparams=[],
             pool_size=pool_size,
-            out_path='./test.csv'
+            out_path='test.csv'
         )
 
         self.assertEqual(
@@ -37,5 +44,5 @@ class TestProcessAllocation(TestCase):
                 fit_model=sncosmo.Model('salt2'),
                 vparams=[],
                 pool_size=3,
-                out_path='./test.csv'
+                out_path='test.csv'
             )

--- a/tests/test_lc_simulation.py
+++ b/tests/test_lc_simulation.py
@@ -126,7 +126,7 @@ class RealizeLC(TestCase):
     def test_runs_with_sncosmo(self):
         """Test the Simulated LC can be fit with ``sncosmo``"""
 
-        sncosmo.fit_lc(self.simulated_lc, self.model, vparam_names=['x0', 'x1', 'c'])
+        sncosmo.fit_lc(self.simulated_lc, self.model, vparam_names=['x0', 'x1', 'c'], warn=False)
 
     def test_correct_meta_data_values(self):
         """Test simulated LC table has model parameters in meta data"""

--- a/tests/test_output_data_model.py
+++ b/tests/test_output_data_model.py
@@ -5,13 +5,17 @@ from unittest import TestCase
 import numpy as np
 import sncosmo
 
+from snat_sim import constants as const
 from snat_sim.fitting_pipeline import OutputDataModel
 
 
 class OutputValueFormatting(TestCase):
+    """Test values are added to the output list in the order matching the output header"""
 
     @classmethod
     def setUpClass(cls):
+        """Run a light-curve fit to determine test data"""
+
         data = sncosmo.load_example_data()
         model = sncosmo.Model('salt2')
         cls.meta = {'SNID': '123'}
@@ -21,30 +25,63 @@ class OutputValueFormatting(TestCase):
             bounds={'z': (0.3, 0.7)})  # bounds on parameters (if any)
 
         cls.formatted_results = OutputDataModel.build_result_table_entry(cls.meta, cls.fitted_model, cls.result)
+        cls.col_names = OutputDataModel.result_table_col_names(cls.fitted_model)
 
-    def test_value_positions_in_output_list(self):
-        """Test values are added to the output list in the order matching the output header"""
+    def test_object_id_position(self):
+        """Test position of SNID in output list"""
 
-        self.assertEqual(self.formatted_results[0], self.meta['SNID'])
+        position = self.col_names.index('SNID')
+        self.assertEqual(self.formatted_results[position], self.meta['SNID'])
 
-        param_start = 1
+    def test_param_value_positions(self):
+        """Test position of parameter values in output list"""
+
+        # Get expected index of first parameter from the column names
+        # Assume parameter values are contiguous in the array
+        first_param = self.fitted_model.param_names[0]
+        param_values_start = self.col_names.index(first_param)
         num_parameters = len(self.fitted_model.parameters)
+
         np.testing.assert_array_equal(
-            self.formatted_results[param_start: num_parameters + param_start],
+            self.formatted_results[param_values_start: num_parameters + param_values_start],
             self.fitted_model.parameters)
 
-        errors_start = num_parameters + param_start
-        errors = list(self.result.errors.values())
+    def test_error_value_positions(self):
+        """Test position of parameter errors in output list"""
+
+        # Get expected index of first parameter from the column names
+        # Assume parameter error values are contiguous in the array
+        first_param = self.fitted_model.param_names[0]
+        errors_start = self.col_names.index(first_param + '_err')
+        num_parameters = len(self.fitted_model.parameters)
+
         np.testing.assert_array_equal(
             self.formatted_results[errors_start: num_parameters + errors_start],
-            errors)
+            list(self.result.errors.values()))
 
-        chisq_start = errors_start + len(errors)
-        np.testing.assert_array_equal(
-            self.formatted_results[chisq_start: chisq_start + 2],
-            [self.result.chisq, self.result.ndof])
+    def test_chisq_position(self):
+        """Test position of chi-squared and degrees of freedom in output list"""
+
+        chisq_index = self.col_names.index('chisq')
+        self.assertEqual(self.formatted_results[chisq_index], self.result.chisq)
+
+        dof_index = self.col_names.index('ndof')
+        self.assertEqual(self.formatted_results[dof_index], self.result.ndof)
+
+    def test_magnitude_position(self):
+        """Test position of magnitude values in output list"""
+
+        mb_index = self.col_names.index('mb')
+        mb = self.fitted_model.bandmag('bessellb', 'ab', time=self.fitted_model['t0'])
+        self.assertEqual(self.formatted_results[mb_index], mb)
+
+        abs_mag_index = self.col_names.index('abs_mag')
+        abs_mag = self.fitted_model.source_peakabsmag('bessellb', 'ab', cosmo=const.betoule_cosmo)
+        self.assertEqual(self.formatted_results[abs_mag_index], abs_mag)
 
     def test_output_length_matches_column_names(self):
+        """Test the number of output values match the number of columns names"""
+
         self.assertEqual(
             len(self.formatted_results),
             len(OutputDataModel.result_table_col_names(self.fitted_model))

--- a/tests/test_output_data_model.py
+++ b/tests/test_output_data_model.py
@@ -1,0 +1,51 @@
+"""Tests for the ``OutputDataModel`` class"""
+
+from unittest import TestCase
+
+import numpy as np
+import sncosmo
+
+from snat_sim.fitting_pipeline import OutputDataModel
+
+
+class OutputValueFormatting(TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        data = sncosmo.load_example_data()
+        model = sncosmo.Model('salt2')
+        cls.meta = {'SNID': '123'}
+        cls.result, cls.fitted_model = sncosmo.fit_lc(
+            data, model,
+            ['z', 't0', 'x0', 'x1', 'c'],  # parameters of model to vary
+            bounds={'z': (0.3, 0.7)})  # bounds on parameters (if any)
+
+        cls.formatted_results = OutputDataModel.build_result_table_entry(cls.meta, cls.fitted_model, cls.result)
+
+    def test_value_positions_in_output_list(self):
+        """Test values are added to the output list in the order matching the output header"""
+
+        self.assertEqual(self.formatted_results[0], self.meta['SNID'])
+
+        param_start = 1
+        num_parameters = len(self.fitted_model.parameters)
+        np.testing.assert_array_equal(
+            self.formatted_results[param_start: num_parameters + param_start],
+            self.fitted_model.parameters)
+
+        errors_start = num_parameters + param_start
+        errors = list(self.result.errors.values())
+        np.testing.assert_array_equal(
+            self.formatted_results[errors_start: num_parameters + errors_start],
+            errors)
+
+        chisq_start = errors_start + len(errors)
+        np.testing.assert_array_equal(
+            self.formatted_results[chisq_start: chisq_start + 2],
+            [self.result.chisq, self.result.ndof])
+
+    def test_output_length_matches_column_names(self):
+        self.assertEqual(
+            len(self.formatted_results),
+            len(OutputDataModel.result_table_col_names(self.fitted_model))
+        )


### PR DESCRIPTION
This PR adds most properties listed in Issue #71. The only missing values are error values on the fitted apparent and absolute B-band magnitude. I'm not sure of the most direct way to do this within the sncosmo framework, so I'm opening this as a draft for now.