### PR TITLE
Update Command Line Interface

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,5 +2,6 @@ guzzle_sphinx_theme
 nbsphinx
 nbsphinx_link
 sphinx
+sphinx-argparse
 sphinx-copybutton
 IPython  # Ensures syntax highlighting in notebook docs

--- a/docs/source/_static/css/custom_style.css
+++ b/docs/source/_static/css/custom_style.css
@@ -50,6 +50,18 @@ dl {
     margin-bottom: 40px;
 }
 
+div.highlight {
+    overflow: hidden;
+}
+
+a.copybtn {
+    margin-right: 5px
+}
+
+div.stderr a.copybtn, div.nboutput a.copybtn {
+    display: none;
+}
+
 /* -- Code and API ---------------------------------------------------------- */
 
 
@@ -62,16 +74,9 @@ dl {
     background: #fafafa;
 }
 
-/* -- Rendered Notebooks ---------------------------------------------------- */
+/* -- Command Line Interface Arguments -------------------------------------- */
 
-div.highlight {
-    overflow: hidden;
-}
-
-a.copybtn {
-    margin-right: 5px
-}
-
-div.stderr a.copybtn, div.nboutput a.copybtn {
-    display: none;
+dl.option-list {
+    padding-left: 100px;
+    padding-right: 150px;
 }

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -35,7 +35,8 @@ extensions = [
     'sphinx_copybutton',
     'nbsphinx',
     'nbsphinx_link',
-    'sphinx.ext.doctest'
+    'sphinx.ext.doctest',
+    'sphinxarg.ext'
 ]
 
 # Syntax highlighting style

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -55,6 +55,7 @@ Collaboration, with particular emphasis on the **Code of Conduct** and
    Introduction<self>
    overview/install.rst
    overview/data_provenance.rst
+   overview/command_line.rst
 
 .. toctree::
    :hidden:

--- a/docs/source/overview/command_line.rst
+++ b/docs/source/overview/command_line.rst
@@ -1,0 +1,12 @@
+Command Line Interface
+======================
+
+A command line interface is provided for running the fitting and simulation
+pipeline. This is particularly useful when running multiple pipeline instances
+for different configuration arguments. An outline of the command line arguments
+and their default values is provided below.
+
+.. argparse::
+   :filename: ../scripts/fitting_cli.py
+   :func: create_cli_parser
+   :prog: fitting_cli.py

--- a/scripts/fitting_cli.py
+++ b/scripts/fitting_cli.py
@@ -12,7 +12,7 @@ from pathlib import Path
 from astropy.table import Table
 from pwv_kpno.defaults import ctio
 
-sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+sys.path.insert(0, str(Path(sys.argv[0]).resolve().parent.parent))
 from snat_sim import filters, models
 from snat_sim.fitting_pipeline import FittingPipeline
 
@@ -128,14 +128,15 @@ def create_cli_parser():
         '-c', '--cadence',
         type=str,
         required=True,
-        help='Cadence to use when simulating light-curves'
+        help='Observational cadence to use when simulating light-curves.'
     )
 
     parser.add_argument(
         '-t', '--source',
         type=str,
         default='salt2-extended',
-        help='The name of the spectral template to use when simulating AND fitting'
+        help='The name of the sncosmo spectral template to use when simulating'
+             ' AND fitting supernova light-curves.'
     )
 
     parser.add_argument(
@@ -143,21 +144,25 @@ def create_cli_parser():
         type=str,
         default=('x0', 'x1', 'c'),
         nargs='+',
-        help='Parameters to vary when fitting'
+        help='Parameters to vary when fitting light-curves.'
     )
 
     parser.add_argument(
         '-s', '--sim_variability',
         type=str,
         required=True,
-        help='Rate at which to vary PWV in simulated light-curves'
+        help='Rate at which to vary PWV when simulating light-curves.'
+             ' Specify a numerical value for a fixed PWV concentration.'
+             ' Specify "epoch" to vary the PWV per observation.'
     )
 
     parser.add_argument(
         '-f', '--fit_variability',
         type=str,
         required=True,
-        help='Rate at which to vary assumed PWV when fitting light-curves'
+        help='Rate at which to vary the assumed PWV when fitting light-curves.'
+             ' Specify a numerical value for a fixed PWV concentration.'
+             ' Specify "epoch" to vary the PWV per observation.'
     )
 
     parser.add_argument(
@@ -171,7 +176,7 @@ def create_cli_parser():
         '-i', '--iter_lim',
         type=int,
         default=float('inf'),
-        help='Limit number of processed light-curves (Useful for profiling)'
+        help='Exit pipeline after processing the given number of light-curves (Useful for profiling).'
     )
 
     parser.add_argument(
@@ -179,14 +184,14 @@ def create_cli_parser():
         type=str,
         default=('G2', 'M5', 'K2'),
         nargs='+',
-        help='Reference star(s) to calibrate simulated SNe against'
+        help='Reference star(s) to calibrate simulated SNe against.'
     )
 
     parser.add_argument(
         '-o', '--out_path',
         type=Path,
         required=True,
-        help='Output file path (in CSV format)'
+        help='Output file path (in CSV format).'
     )
 
     for param in SALT2_PARAMS:
@@ -195,7 +200,7 @@ def create_cli_parser():
             type=float,
             default=None,
             nargs=2,
-            help=f'Upper and lower bounds for {param} parameter when fitting light-curves'
+            help=f'Upper and lower bounds for {param} parameter when fitting light-curves.'
         )
 
     parser.set_defaults(func=run_pipeline)


### PR DESCRIPTION
This PR updates the command line interface to support the new ``bounds`` argument added in #87 for ``FittingPipeline`` objects. It adds five new arguments  `--bound_[z, to, x0, x1, c]`, each of which take a two-element list of floats that represents minimization boundaries for each Salt2 parameter.

Since I was working on the CLI anyway, I also addressed #89. When a constant PWV variability is specified, the pipeline now uses a `StaticPWVTrans` instance, which does not include airmass scaling. 

(Closes #89)