### PR TITLE
Reduces PWV sampling rate in FixedResTransmission

### DIFF
--- a/snat_sim/models.py
+++ b/snat_sim/models.py
@@ -97,7 +97,7 @@ class FixedResTransmission:
 
         self.norm_pwv = 2
         self.eff_exp = 0.6
-        self.samp_pwv = np.arange(0, 75.1, .1)
+        self.samp_pwv = np.arange(0, 60.25, .25)
         self.samp_wave = v1_transmission.samp_wave
         self.samp_transmission = v1_transmission(
             pwv=self.samp_pwv,


### PR DESCRIPTION
This PR addresses #94 by reducing the number of sampled PWV transmission functions used by `FixedResTransmission`.
The upper bound on the PWV concentration is lowered to 60 mm and the sampling rate is dropped from `.1` to `.25`. 
This reduces the number of sampled PWV values (and the init time) by about 30%.