### PR TITLE
Patches empty dict error

### DIFF
--- a/scripts/profiling/profile_fitting.py
+++ b/scripts/profiling/profile_fitting.py
@@ -1,12 +1,11 @@
 import os
-from pathlib import Path
 
 from pwv_kpno.defaults import ctio
 
 from snat_sim import models
 from snat_sim.pipeline import FittingPipeline
 
-os.environ['CADENCE_SIMS'] = str(Path(__file__).resolve().parent / 'data')
+os.environ['CADENCE_SIMS'] = '/mnt/md0/sn-sims/'
 
 
 def setup_pipeline():
@@ -25,7 +24,7 @@ def setup_pipeline():
         effect_names=[''],
         effect_frames=['obs'])
 
-    return FittingPipeline(
+    pipeline = FittingPipeline(
         cadence='alt_sched',
         sim_model=sn_model_sim,
         fit_model=sn_model_fit,
@@ -34,8 +33,15 @@ def setup_pipeline():
         fitting_pool=6,
         out_path='./test.csv',
         max_queue=1000,
-        iter_lim=100
+        iter_lim=1500
     )
+
+    # Run the pipeline in the main thread
+    pipeline.load_plastic.num_processes = 0
+    pipeline.simulate_light_curves.num_processes = 0
+    pipeline.fit_light_curves.num_processes = 0
+    pipeline.fits_to_disk.num_processes = 0
+    return pipeline
 
 
 if __name__ == '__main__':

--- a/snat_sim/pipeline.py
+++ b/snat_sim/pipeline.py
@@ -256,7 +256,9 @@ class SimulateLightCurves(Node):
                 duplicated_lc = self.duplicate_plasticc_lc(params, cadence)
 
             except Exception as e:
-                result = PipelineResult(params['SNID'], sim_params=params, message=str(e))
+                result = PipelineResult(
+                    params['SNID'], sim_params=params,
+                    message=f'{self.__class__.__name__}: {e}')
                 self.failure_result_output.put(result)
 
             else:

--- a/snat_sim/utils/caching.py
+++ b/snat_sim/utils/caching.py
@@ -76,9 +76,9 @@ class MemoryCache(OrderedDict):
         super(MemoryCache, self).__init__()
 
         self.max_size = max_size
-        size_when_empty = sys.getsizeof(self)
-        if (self.max_size is not None) and (self.max_size <= size_when_empty):
-            raise ValueError(f'MemoryCache size limit must exceed {size_when_empty} bytes')
+        if max_size is not None:
+            if not isinstance(max_size, int) or max_size <= 0:
+                raise ValueError('Maximum cache size must be a positive integer')
 
     def __setitem__(self, key: Hashable, value: Any):
         """Update an entry in the hash table."""
@@ -90,7 +90,7 @@ class MemoryCache(OrderedDict):
         """Pop items from memory until instance size is <= the size limit."""
 
         if self.max_size is not None:
-            while sys.getsizeof(self) > self.max_size:
+            while self and sys.getsizeof(self) > self.max_size:
                 self.popitem(last=False)
 
 

--- a/tests/test_utils/test_caching.py
+++ b/tests/test_utils/test_caching.py
@@ -10,13 +10,7 @@ from snat_sim.utils.caching import MemoryCache
 
 
 class MemoryManagement(TestCase):
-    """Tests for the ``MemoryCache`` class"""
-
-    def test_error_on_zero_size_limit(self) -> None:
-        """Test an error is raise when instantiating a MemoryCache of size zero"""
-
-        with self.assertRaises(ValueError):
-            MemoryCache(max_size=0)
+    """Tests for the enforcement of a limit on the consumed memory"""
 
     def test_max_size_is_enforced(self) -> None:
         """Test the memory cache enforces the prescribed size limit as data is added / removed"""
@@ -67,3 +61,25 @@ class NumpyCache(TestCase):
             return x + y
 
         add(np.array([1, 2]), np.array([1, 2]))
+
+
+class InitErrors(TestCase):
+    """Tests for the raising of errors on init"""
+
+    def test_error_on_zero_size_limit(self) -> None:
+        """Test an error is raise when instantiating a MemoryCache of size zero"""
+
+        with self.assertRaises(ValueError):
+            MemoryCache(max_size=0)
+
+    def test_error_on_negative_size_limit(self) -> None:
+        """Test an error is raise when instantiating a MemoryCache of negative size"""
+
+        with self.assertRaises(ValueError):
+            MemoryCache(max_size=-1)
+
+    def test_error_on_float_size_limit(self) -> None:
+        """Test an error is raise when instantiating a MemoryCache with a float"""
+
+        with self.assertRaises(ValueError):
+            MemoryCache(max_size=1.2)


### PR DESCRIPTION
**Issue:** The `Cache` class occasionally raises a `KeyError` when trying to add a new item. 

**Source:** The memory management subroutine was trying to lessen the size of the cache by removing cached entries, except the cache was already empty.

```python
if self.max_size is not None:
    while sys.getsizeof(self) > self.max_size:
        self.popitem(last=False)
```

It looks like the `max_size` attribute was getting set incorrectly during instantiation, and was actually smaller than the empty dictionary. 

In principle, there were checks in place to prevent this exact situation:

```python
# In __init__
self.max_size = max_size
size_when_empty = sys.getsizeof(self)
if (self.max_size is not None) and (self.max_size <= size_when_empty):
    raise ValueError(f'MemoryCache size limit must exceed {size_when_empty} bytes')
``` 

I'm not sure why this doesn't work. My best guess is that the instance is mutated in some way after instantiation that increases the size without necessarily increasing the number of cached items.

**Solution:** Instead of checking the empty cache size at init, allowed the cache size to be any positive, integer size. I also added explicit handling of an empty instance to the memory management method. 
 