### PR TITLE
Removes fitted model from pipeline packet

### DIFF
--- a/scripts/interactive_lc_simulation/interactive_lc_simulation.py
+++ b/scripts/interactive_lc_simulation/interactive_lc_simulation.py
@@ -1,6 +1,7 @@
 """Interactive Bokeh application for plotting light-curve simulations"""
 
 import sys
+from copy import copy
 from pathlib import Path
 
 import numpy as np
@@ -207,13 +208,17 @@ class Callbacks(SimulatedParamWidgets, FittedParamWidgets):
         )
 
         try:
-            result, fitted_model = self.sn_model_without_pwv.fit_lc(
+            result = self.sn_model_without_pwv.fit_lc(
                 self.sim_data,
                 vparam_names=['t0', 'x0', 'x1', 'c'])
 
         except Exception as e:
             self.fit_results_div.update(text=str(e))
             return
+
+        else:
+            fitted_model = copy(self.sn_model_without_pwv)
+            fitted_model.update(dict(zip(result.param_names, result.parameters)))
 
         # Set fitted param sliders to reflect the fitted parameters
         self.fit_t0_slider.update(value=fitted_model['t0'])

--- a/snat_sim/models/__init__.py
+++ b/snat_sim/models/__init__.py
@@ -126,13 +126,13 @@ Notice in the below example that the returned object types are classes from the
 .. doctest:: python
 
    >>> supernova_model.set(z=.5, t0=55100.0)
-   >>> fit_result, fitted_model = supernova_model.fit_lc(
+   >>> fit_result = supernova_model.fit_lc(
    ...     light_curve_data, vparam_names=['x0', 'x1', 'c'])
 
    >>> print(type(fit_result))
    <class 'snat_sim.models.supernova.SNFitResult'>
 
-   >>> print(type(fitted_model))
+   >>> print(type(fit_result.fitted_model))
    <class 'snat_sim.models.supernova.SNModel'>
 
 The ``SNFitResult`` object is similar to the ``Result`` class from ``sncosmo``

--- a/snat_sim/models/__init__.py
+++ b/snat_sim/models/__init__.py
@@ -51,10 +51,10 @@ The ``SNModel`` class from ``snat_sim`` acts as a drop-in replacement for
 the ``Model`` classes built into ``sncosmo`` but provides extended
 functionality.
 
-Supernova models are instantiated using a spectral template with the addition of
-optional observer or rest-frame effects. In the
-following example, atmospheric propagation effects due to precipitable water
-vapor are added to a Salt2 supernova model.
+Supernova models are instantiated using a spectral template with the addition
+of optional observer or rest-frame effects. In the following example,
+atmospheric propagation effects due to precipitable water vapor are added
+to a Salt2 supernova model.
 
 .. doctest:: python
 
@@ -131,9 +131,6 @@ as ``sncosmo``.:
 
    >>> print(type(fit_result))
    <class 'snat_sim.models.supernova.SNFitResult'>
-
-   >>> print(type(fit_result.fitted_model))
-   <class 'snat_sim.models.supernova.SNModel'>
 
 The ``SNFitResult`` object is similar to the ``Result`` class from ``sncosmo``
 but **is not backward compatible**. ``SNFitResult`` instances provide access

--- a/snat_sim/models/__init__.py
+++ b/snat_sim/models/__init__.py
@@ -120,8 +120,8 @@ Fitting Light-Curves
 ^^^^^^^^^^^^^^^^^^^^
 
 Photometric data can be fit directly from the model using the ``fit_lc`` method.
-Notice in the below example that the returned object types are classes from the
-``snat_sim`` package:
+``sncosmo`` users should note that the return signature is not the same
+as ``sncosmo``.:
 
 .. doctest:: python
 

--- a/snat_sim/models/supernova.py
+++ b/snat_sim/models/supernova.py
@@ -14,6 +14,7 @@ import sncosmo
 
 from .light_curve import LightCurve, ObservedCadence
 from .pwv import VariablePropagationEffect
+from .. import constants as const
 from .. import types
 
 
@@ -156,7 +157,7 @@ class SNModel(sncosmo.Model):
             maxcall: int = 10000,
             phase_range: List[types.Numeric] = None,
             wave_range: List[types.Numeric] = None
-    ) -> Tuple[SNFitResult, SNModel]:
+    ) -> SNFitResult:
         """Fit model parameters to photometric data via a chi-squared minimization
 
         Fitting behavior:
@@ -206,7 +207,10 @@ class SNModel(sncosmo.Model):
             warn=False
         )
 
-        return SNFitResult(result), SNModel.from_sncosmo(fitted_model)
+        result = SNFitResult(result)
+        result['apparent_bessellb'] = fitted_model.source.bandmag('bessellb', 'ab', phase=0)
+        result['absolute_bessellb'] = fitted_model.source_peakabsmag('bessellb', 'ab', cosmo=const.betoule_cosmo)
+        return result
 
 
 class SNFitResult(sncosmo.utils.Result):

--- a/snat_sim/pipeline/nodes.py
+++ b/snat_sim/pipeline/nodes.py
@@ -205,7 +205,7 @@ class FitLightCurves(Node):
 
         for packet in self.input.iter_get():
             try:
-                packet.fit_result, packet.fitted_model = self.fit_lc(packet.light_curve, packet.sim_params)
+                packet.fit_result = self.fit_lc(packet.light_curve, packet.sim_params)
                 packet.covariance = packet.fit_result.salt_covariance_linear()
 
             except Exception as excep:

--- a/tests/mock.py
+++ b/tests/mock.py
@@ -151,7 +151,7 @@ def create_mock_pipeline_packet(
         packet.light_curve = model.simulate_lc(cadence)
 
         if include_fit:
-            packet.fit_result, packet.fitted_model = model.fit_lc(packet.light_curve, ['x0', 'x1', 'c'])
+            packet.fit_result = model.fit_lc(packet.light_curve, ['x0', 'x1', 'c'])
             packet.covariance = packet.fit_result.salt_covariance_linear()
 
     return packet

--- a/tests/test_pipeline/test_data_model/testPipelinePacket.py
+++ b/tests/test_pipeline/test_data_model/testPipelinePacket.py
@@ -60,9 +60,11 @@ class FittedParamsToPandas(TestCase):
         fit_params = ['snid']
         fit_params.extend('fit_' + param for param in self.packet.fit_result.param_names)
         fit_params.extend('err_' + param for param in self.packet.fit_result.param_names)
-        fit_params.extend(('chisq', 'ndof', 'mb', 'abs_mag'))
+
+        # Compare just the first few columns which are generated dynamically
+        # using the parameter names. Ignore the static names.
         columns = self.packet.fitted_params_to_pandas().columns
-        np.testing.assert_array_equal(fit_params, columns)
+        np.testing.assert_array_equal(fit_params, columns[:len(fit_params)])
 
     def test_values_match_params(self) -> None:
         """Test the values of the returned dataframe match simulated parameters"""
@@ -73,8 +75,8 @@ class FittedParamsToPandas(TestCase):
         self.assertEqual(self.packet.fit_result.chisq, returned_data['chisq'], 'Incorrect chisq')
         self.assertEqual(self.packet.fit_result.ndof, returned_data['ndof'], 'Incorrect ndof')
 
-        for param in self.packet.fit_result.param_names:
-            fit_result = self.packet.fitted_model[param]
+        for i, param in enumerate(self.packet.fit_result.param_names):
+            fit_result = self.packet.fit_result.parameters[i]
             return_val = returned_data[f'fit_{param}']
             self.assertEqual(fit_result, return_val, f'Incorrect fit value for {param}')
 

--- a/tests/test_pipeline/test_nodes/testFitLightCurves.py
+++ b/tests/test_pipeline/test_nodes/testFitLightCurves.py
@@ -27,7 +27,7 @@ class GenericSetup:
 
         # Create a mock pipeline for fitting the packet's light-curve
         source = MockSource([cls.packet])
-        cls.node = FitLightCurves(SNModel('salt2-extended'), vparams=vparams, num_processes=0)
+        cls.node = FitLightCurves(SNModel('salt2-extended'), vparams=vparams)
         cls.success_target = MockTarget()
         cls.failure_target = MockTarget()
 
@@ -54,14 +54,13 @@ class SuccessfulFitOutput(TestCase, GenericSetup):
         """Check each individual output value from the fitting node"""
 
         # Calculate expected values
-        fitted_result, fitted_model = self.node.fit_lc(self.packet.light_curve, self.packet.sim_params)
+        fitted_result = self.node.fit_lc(self.packet.light_curve, self.packet.sim_params)
 
         # Compare those results against actual values
         pipeline_result = self.success_target.accumulated_data[0]
         self.assertEqual(self.packet.snid, pipeline_result.snid)
         self.assertEqual(self.packet.sim_params, pipeline_result.sim_params)
         self.assertEqual(fitted_result, pipeline_result.fit_result)
-        np.testing.assert_array_equal(fitted_model.parameters, pipeline_result.fitted_model.parameters)
         self.assertEqual('FitLightCurves: Minimization exited successfully.', pipeline_result.message)
 
 

--- a/tests/test_pipeline/test_nodes/testLoadPlasticcCadence.py
+++ b/tests/test_pipeline/test_nodes/testLoadPlasticcCadence.py
@@ -18,7 +18,7 @@ class LoadsCorrectSimulationData(TestCase):
 
         # Create a mock pipeline
         cadence = PLAsTICC('alt_sched', 11)
-        load_action = LoadPlasticcCadence(cadence, num_processes=0)
+        load_action = LoadPlasticcCadence(cadence)
         mock_target = MockTarget()
 
         # Execute the pipeline

--- a/tests/test_pipeline/test_nodes/testSimulateLightCurves.py
+++ b/tests/test_pipeline/test_nodes/testSimulateLightCurves.py
@@ -18,7 +18,7 @@ class ResultRouting(TestCase):
 
         # Set up separate target node for each of the ``SimulateLightCurves`` output connectors
         self.source = MockSource()
-        self.node = SimulateLightCurves(SNModel('salt2-extended'), num_processes=0)
+        self.node = SimulateLightCurves(SNModel('salt2-extended'))
         self.success_target = MockTarget()
         self.failure_target = MockTarget()
 


### PR DESCRIPTION
Egon has moved to using a new parallelization back end. `sncosmo` models can no longer be passed around between nodes because they cannot be serialized.