### PR TITLE
Updates pipeline packet with x0 value actually used in sims

### DIFF
--- a/snat_sim/pipeline/nodes.py
+++ b/snat_sim/pipeline/nodes.py
@@ -137,22 +137,22 @@ class SimulateLightCurves(Node):
         if self.catalog is not None:
             duplicated = self.catalog.calibrate_lc(duplicated, ra=params['ra'], dec=params['dec'])
 
-        return duplicated
+        return duplicated, model_for_sim
 
     def action(self) -> None:
         """Simulate light-curves with atmospheric effects"""
 
         for packet in self.input.iter_get():
             try:
-                packet.light_curve = self.simulate_lc(
-                    packet.sim_params, packet.cadence
-                )
+                light_curve, model = self.simulate_lc(packet.sim_params, packet.cadence)
 
             except Exception as excep:
                 packet.message = f'{self.__class__.__name__}: {repr(excep)}'
                 self.failure_output.put(packet)
 
             else:
+                packet.light_curve = light_curve
+                packet.sim_params['x0'] = model['x0']
                 self.success_output.put(packet)
 
 

--- a/snat_sim/pipeline/nodes.py
+++ b/snat_sim/pipeline/nodes.py
@@ -117,7 +117,7 @@ class SimulateLightCurves(Node):
         self.failure_output = Output('Simulation Failure')
         super().__init__(num_processes=num_processes)
 
-    def simulate_lc(self, params: Dict[str, float], cadence: ObservedCadence) -> LightCurve:
+    def simulate_lc(self, params: Dict[str, float], cadence: ObservedCadence) -> Tuple[LightCurve, SNModel]:
         """Duplicate a plastic light-curve using the simulation model
 
         Args:

--- a/tests/test_pipeline/test_nodes/testSimulateLightCurves.py
+++ b/tests/test_pipeline/test_nodes/testSimulateLightCurves.py
@@ -68,10 +68,10 @@ class LightCurveSimulation(TestCase):
         packet = create_mock_pipeline_packet(include_lc=False)
 
         node_without_catalog = SimulateLightCurves(model, add_scatter=False)
-        uncalibrated_lc = node_without_catalog.simulate_lc(packet.sim_params, packet.cadence)
+        uncalibrated_lc, _ = node_without_catalog.simulate_lc(packet.sim_params, packet.cadence)
 
         node_with_catalog = SimulateLightCurves(model, add_scatter=False, catalog=catalog)
-        calibrated_lc = node_with_catalog.simulate_lc(packet.sim_params, packet.cadence)
+        calibrated_lc, _ = node_with_catalog.simulate_lc(packet.sim_params, packet.cadence)
 
         ra, dec = packet.sim_params['ra'], packet.sim_params['dec']
         pd.testing.assert_frame_equal(


### PR DESCRIPTION
While looking over pipeline results a few weeks ago, @wmwv pointed out the fitted `x0` parameters disagree with the simulated `x0` parameters in a way that look suspiciously like a mishandling of the assumed cosmology during the analysis process.

After some extensive digging, I realized the analysis pipeline is writing to disk the `x0` value used by the plasticc team. This is different than the `x0` value **we** are using. The assumed cosmologies between these values are different. 