### PR TITLE
Fix bug where SNID are floats in output file

### DIFF
--- a/snat_sim/pipeline/data_model.py
+++ b/snat_sim/pipeline/data_model.py
@@ -78,9 +78,9 @@ class PipelinePacket:
             Parameters used in the simulation of light-curves
         """
 
-        out_data = pd.Series(self.sim_params)
-        out_data['snid'] = self.snid
-        return pd.DataFrame(out_data).T
+        out_data = pd.DataFrame([self.sim_params])
+        out_data['snid'] = [self.snid]
+        return out_data
 
     def fitted_params_to_pandas(self) -> pd.DataFrame:
         """Return fitted parameters as a pandas Dataframe
@@ -99,7 +99,6 @@ class PipelinePacket:
         col_names.append('ndof')
         col_names.append('apparent_bessellb')
         col_names.append('absolute_bessellb')
-        # col_names.append('message')
 
         data_list = [self.snid]
         data_list.extend(self.fit_result.parameters)
@@ -108,7 +107,7 @@ class PipelinePacket:
         data_list.append(self.fit_result.ndof)
         data_list.append(self.fit_result.apparent_bessellb)
         data_list.append(self.fit_result.absolute_bessellb)
-        return pd.DataFrame(pd.Series(data_list, index=col_names)).T
+        return pd.DataFrame([data_list], columns=col_names)
 
     def packet_status_to_pandas(self) -> pd.DataFrame:
         """Return the packet status message as a pandas ``DataFrame``

--- a/snat_sim/pipeline/nodes.py
+++ b/snat_sim/pipeline/nodes.py
@@ -290,8 +290,8 @@ class WritePipelinePacket(Target):
         self._rotate_output_file()
 
         # We are taking the simulated parameters as guaranteed to exist
-        self.file_store.append('simulation/params', packet.sim_params_to_pandas(), min_itemsize={'snid': 10})
-        self.file_store.append('message', packet.packet_status_to_pandas().astype(str), min_itemsize={'snid': 10, 'message': 250})
+        self.file_store.append('simulation/params', packet.sim_params_to_pandas())
+        self.file_store.append('message', packet.packet_status_to_pandas(), min_itemsize={'message': 250})
 
         if self.write_lc_sims and packet.light_curve is not None:
             self.file_store.put(f'simulation/lcs/{packet.snid}', packet.light_curve.to_pandas())

--- a/tests/test_pipeline/test_data_model/testPipelinePacket.py
+++ b/tests/test_pipeline/test_data_model/testPipelinePacket.py
@@ -38,6 +38,13 @@ class SimParamsToPandas(TestCase):
         for key, val in self.packet.sim_params.items():
             self.assertEqual(val, returned_params[key])
 
+    # Regression test
+    def test_snid_is_integer(self) -> None:
+        """Test the SNID value is an integer"""
+
+        test_data = self.packet.sim_params_to_pandas()
+        self.assertTrue(issubclass(test_data['snid'].dtype.type, np.integer))
+
 
 class FittedParamsToPandas(TestCase):
     """Test the casting of fitted parameters to a pandas object"""
@@ -92,6 +99,12 @@ class FittedParamsToPandas(TestCase):
         with self.assertRaises(ValueError):
             packet.fitted_params_to_pandas()
 
+    def test_snid_is_integer(self) -> None:
+        """Test the SNID value is an integer"""
+
+        test_data = self.packet.fitted_params_to_pandas()
+        self.assertTrue(issubclass(test_data['snid'].dtype.type, np.integer))
+
 
 class PacketStatusToPandas(TestCase):
     """Tests for the compilation of packet status indicators into a DataFrame"""
@@ -115,3 +128,9 @@ class PacketStatusToPandas(TestCase):
         self.assertEqual(packet.snid, df_data['snid'])
         self.assertEqual(packet.message, df_data['message'])
         self.assertEqual(False, df_data['success'])
+
+    def test_snid_is_integer(self) -> None:
+        """Test the SNID value is an integer"""
+
+        test_data = create_mock_pipeline_packet().packet_status_to_pandas()
+        self.assertTrue(issubclass(test_data['snid'].dtype.type, np.integer))

--- a/tests/test_pipeline/test_nodes/testWritePipelinePacket.py
+++ b/tests/test_pipeline/test_nodes/testWritePipelinePacket.py
@@ -24,10 +24,10 @@ class InputDataMatchesDisk(TestCase):
 
         node = WritePipelinePacket(Path(cls.temp_dir.name) / 'tempfile.h5', True)
         node.debug = True
-        moc_source = MockSource(cls.packets)
-        moc_source.output.connect(node.input)
+        mock_source = MockSource(cls.packets)
+        mock_source.output.connect(node.input)
 
-        moc_source.execute()
+        mock_source.execute()
         node.execute()
 
         # Account for the rotation of output files
@@ -70,10 +70,8 @@ class InputDataMatchesDisk(TestCase):
     def test_status_matches_packet(self) -> None:
         """Test the status messages written to disk match the packet data"""
 
-        # This table contains mixed data types, so the output node
-        # converts it all to strings when writing to disk
         data_from_packets = pd.concat([p.packet_status_to_pandas() for p in self.packets])
-        data_from_packets = data_from_packets.astype(str)
+        data_from_packets = data_from_packets
 
         data_from_file = pd.read_hdf(self.temp_path, 'message')
         pd.testing.assert_frame_equal(data_from_packets, data_from_file)


### PR DESCRIPTION
The SNID value was sometimes written as a float and sometimes as an object. Now it is always an int. This makes table joins easier.